### PR TITLE
Multi return

### DIFF
--- a/source/ddbus/router.d
+++ b/source/ddbus/router.d
@@ -99,7 +99,10 @@ class MessageRouter {
       auto retMsg = call.createReturn();
       static if(!is(Ret == void)) {
         Ret ret = handler(args.expand);
-        retMsg.build(ret);
+        static if (is(Ret == Tuple!T, T...))
+          retMsg.build!T(ret.expand);
+        else
+          retMsg.build(ret);
       } else {
         handler(args.expand);
       }

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -98,6 +98,13 @@ string typeSig(T)() if(canDBus!T) {
   }
 }
 
+string[] typeSigReturn(T)() if(canDBus!T) {
+  static if(is(T == Tuple!TS, TS...))
+    return typeSigArr!TS;
+  else
+    return [typeSig!T];
+}
+
 string typeSigAll(TS...)() if(allCanDBus!TS) {
   string sig = "";
   foreach(i,T; TS) {


### PR DESCRIPTION
Breaking change, if a function returns a tuple it will now treat it as multiple returns/multiple out parameters (use a `Tuple!(Tuple!(...))` for the old behaviour). Without breaking the code even more it wasn't possible to make `out` parameters do this because it would mean a lot of changes.