### PR TITLE
Support for dynamic variants (fix #9)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,8 +67,9 @@ import ddbus;
 MessageRouter router = new MessageRouter();
 // create a pattern to register a handler at a path, interface and method
 MessagePattern patt = MessagePattern("/root","ca.thume.test","test");
-router.setHandler!(int,int)(patt,(int par) {
-  writeln("Called with ", par);
+router.setHandler!(int,int,Variant!DBusAny)(patt,(int par, Variant!DBusAny anyArgument) {
+  // anyArgument can contain any type now, it must be specified as argument using Variant!DBusAny.
+  writeln("Called with ", par, ", ", anyArgument);
   return par;
 });
 // handle a signal

--- a/source/ddbus/router.d
+++ b/source/ddbus/router.d
@@ -202,6 +202,8 @@ unittest{
   router.setHandler!(void,int,string)(patt,(int p, string p2) {});
   patt = MessagePattern("/root/wat","ca.thume.tester","lolwut");
   router.setHandler!(int,int)(patt,(int p) {return 6;});
+  patt = MessagePattern("/root/bar","ca.thume.tester","lolwut");
+  router.setHandler!(Variant!DBusAny,int)(patt,(int p) {return variant(DBusAny(p));});
   patt = MessagePattern("/root/foo","ca.thume.tester","lolwut");
   router.setHandler!(Tuple!(string,string,int),int,Variant!DBusAny)(patt,(int p, Variant!DBusAny any) {Tuple!(string,string,int) ret; ret[0] = "a"; ret[1] = "b"; ret[2] = p; return ret;});
   patt = MessagePattern("/troll","ca.thume.tester","wow");
@@ -214,7 +216,7 @@ unittest{
 
   // TODO: these tests rely on nondeterministic hash map ordering
   static string introspectResult = `<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node name="/root"><interface name="ca.thume.test"><method name="test"><arg type="i" direction="in"/><arg type="i" direction="out"/></method></interface><interface name="ca.thume.tester"><method name="lolwut"><arg type="i" direction="in"/><arg type="s" direction="in"/></method></interface><node name="foo"/><node name="wat"/></node>`;
+<node name="/root"><interface name="ca.thume.test"><method name="test"><arg type="i" direction="in"/><arg type="i" direction="out"/></method></interface><interface name="ca.thume.tester"><method name="lolwut"><arg type="i" direction="in"/><arg type="s" direction="in"/></method></interface><node name="bar"/><node name="foo"/><node name="wat"/></node>`;
   router.introspectXML("/root").assertEqual(introspectResult);
   static string introspectResult2 = `<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/root/foo"><interface name="ca.thume.tester"><method name="lolwut"><arg type="i" direction="in"/><arg type="v" direction="in"/><arg type="s" direction="out"/><arg type="s" direction="out"/><arg type="i" direction="out"/></method></interface></node>`;

--- a/source/ddbus/simple.d
+++ b/source/ddbus/simple.d
@@ -74,7 +74,7 @@ void registerMethods(T : Object)(MessageRouter router, string path, string iface
 unittest {
   import dunit.toolkit;
   class Tester {
-    int lol(int x, string s, string[string] map) {return 5;}
+    int lol(int x, string s, string[string] map, Variant!DBusAny any) {return 5;}
     void wat() {}
     @SignalMethod
     void signalRecv() {}
@@ -91,6 +91,6 @@ unittest {
   patt.signal = false;
   router.callTable.assertHasKey(patt);
   auto res = router.callTable[patt];
-  res.argSig.assertEqual(["i","s", "a{ss}"]);
+  res.argSig.assertEqual(["i","s","a{ss}","v"]);
   res.retSig.assertEqual(["i"]);
 }

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -292,8 +292,10 @@ struct DBusAny {
       if(type != 'a' || !signature || signature[0] != '{')
         throw new Exception("Can't convert type " ~ cast(char) type ~ " to " ~ T.stringof);
       T ret;
-      foreach(pair; array)
+      foreach(pair; array) {
+        enforce(pair.type == 'e');
         ret[pair.entry.key.to!(KeyType!T)] = pair.entry.value.to!(ValueType!T);
+      }
       return ret;
     } else static assert(false, "Can't convert variant to " ~ T.stringof);
   }

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -7,6 +7,10 @@ import ddbus.util;
 import std.string;
 import std.typecons;
 import std.exception;
+import std.traits;
+import std.conv;
+import std.range;
+import std.algorithm;
 
 class DBusException : Exception {
   this(DBusError *err) {
@@ -26,7 +30,265 @@ T wrapErrors(T)(T delegate(DBusError *err) del) {
   return ret;
 }
 
+/// Structure allowing typeless parameters
+struct DBusAny {
+  /// DBus type of the value (never 'v'), see typeSig!T
+  int type;
+  /// Child signature for Arrays & Tuples
+  char[] signature;
+  /// If true, this value will get serialized as variant value, otherwise it is serialized like it wasn't in a DBusAny wrapper.
+  /// Same functionality as Variant!T but with dynamic types if true.
+  bool explicitVariant;
+
+  union
+  {
+    ///
+    byte int8;
+    ///
+    short int16;
+    ///
+    ushort uint16;
+    ///
+    int int32;
+    ///
+    uint uint32;
+    ///
+    long int64;
+    ///
+    ulong uint64;
+    ///
+    double float64;
+    ///
+    string str;
+    ///
+    bool boolean;
+    ///
+    DBusAny[] array;
+    ///
+    DBusAny[] tuple;
+    ///
+    DictionaryEntry!(DBusAny, DBusAny)* entry;
+  }
+
+  /// Manually creates a DBusAny object using a type, signature and implicit specifier.
+  this(int type, char[] signature, bool explicit) {
+    this.type = type;
+    this.signature = signature;
+    this.explicitVariant = explicit;
+  }
+
+  /// Automatically creates a DBusAny object with fitting parameters from a D type or Variant!T.
+  /// Pass a `Variant!T` to make this an explicit variant.
+  this(T)(T value) {
+    static if(is(T == byte) || is(T == ubyte)) {
+      this(typeCode!byte, null, false);
+      int8 = cast(byte) value;
+    } else static if(is(T == short)) {
+      this(typeCode!short, null, false);
+      int16 = cast(short) value;
+    } else static if(is(T == ushort)) {
+      this(typeCode!ushort, null, false);
+      uint16 = cast(ushort) value;
+    } else static if(is(T == int)) {
+      this(typeCode!int, null, false);
+      int32 = cast(int) value;
+    } else static if(is(T == uint)) {
+      this(typeCode!uint, null, false);
+      uint32 = cast(uint) value;
+    } else static if(is(T == long)) {
+      this(typeCode!long, null, false);
+      int64 = cast(long) value;
+    } else static if(is(T == ulong)) {
+      this(typeCode!ulong, null, false);
+      uint64 = cast(ulong) value;
+    } else static if(is(T == double)) {
+      this(typeCode!double, null, false);
+      float64 = cast(double) value;
+    } else static if(isSomeString!T) {
+      this(typeCode!string, null, false);
+      str = value.to!string;
+    } else static if(is(T == bool)) {
+      this(typeCode!bool, null, false);
+      boolean = cast(bool) value;
+    } else static if(is(T == Variant!R, R)) {
+      static if(is(R == DBusAny)) {
+        type = value.data.type;
+        signature = value.data.signature;
+        explicitVariant = true;
+        if(type == 'a' || type == 'r')
+          array = value.data.array;
+        if(type == 's')
+          str = value.data.str;
+        else if(type == 'e')
+          entry = value.data.entry;
+        else
+          uint64 = value.data.uint64;
+      } else {
+        this(value.data);
+        explicitVariant = true;
+      }
+    } else static if(is(T : DictionaryEntry!(K, V), K, V)) {
+      this('e', null, false);
+      entry = new DictionaryEntry!(DBusAny, DBusAny)();
+      static if(is(K == DBusAny))
+        entry.key = value.key;
+      else
+        entry.key = DBusAny(value.key);
+      static if(is(V == DBusAny))
+        entry.value = value.value;
+      else
+        entry.value = DBusAny(value.value);
+    } else static if(isInputRange!T) {
+      this.type = 'a';
+      this.signature = typeSig!(ElementType!T).dup;
+      this.explicitVariant = false;
+      foreach(elem; value)
+        array ~= DBusAny(elem);
+    } else static if(isTuple!T) {
+      this.type = 'r';
+      this.signature = ['('];
+      this.explicitVariant = false;
+      foreach(index, R; value.Types) {
+        auto var = DBusAny(value[index]);
+        tuple ~= var;
+        if(var.explicitVariant)
+          this.signature ~= 'v';
+        else {
+          if (var.type != 'r')
+            this.signature ~= cast(char) var.type;
+          if(var.type == 'a' || var.type == 'r')
+            this.signature ~= var.signature;
+        }
+      }
+      this.signature ~= ')';
+    } else static if(isAssociativeArray!T) {
+      this(value.byDictionaryEntries);
+    } else static assert(false, T.stringof ~ " not convertible to a Variant");
+  }
+
+  ///
+  string toString() const {
+    string valueStr;
+    switch(type) {
+    case typeCode!byte:
+      valueStr = int8.to!string;
+      break;
+    case typeCode!short:
+      valueStr = int16.to!string;
+      break;
+    case typeCode!ushort:
+      valueStr = uint16.to!string;
+      break;
+    case typeCode!int:
+      valueStr = int32.to!string;
+      break;
+    case typeCode!uint:
+      valueStr = uint32.to!string;
+      break;
+    case typeCode!long:
+      valueStr = int64.to!string;
+      break;
+    case typeCode!ulong:
+      valueStr = uint64.to!string;
+      break;
+    case typeCode!double:
+      valueStr = float64.to!string;
+      break;
+    case typeCode!string:
+      valueStr = '"' ~ str ~ '"';
+      break;
+    case typeCode!bool:
+      valueStr = boolean ? "true" : "false";
+      break;
+    case 'a':
+      valueStr = '[' ~ array.map!(a => a.toString).join(", ") ~ ']';
+      break;
+    case 'r':
+      valueStr = '(' ~ array.map!(a => a.toString).join(", ") ~ ')';
+      break;
+    case 'e':
+      valueStr = entry.key.toString ~ ": " ~ entry.value.toString;
+      break;
+    default:
+      valueStr = "unknown";
+      break;
+    }
+    return "DBusAny(" ~ cast(char) type
+      ~ ", \"" ~ signature.idup
+      ~ "\", " ~ (explicitVariant ? "explicit" : "implicit")
+      ~ ", " ~ valueStr ~ ")";
+  }
+
+  /// If the value is an array of DictionaryEntries this will return a HashMap
+  DBusAny[DBusAny] toAA() {
+    enforce(type == 'a' && signature && signature[0] == '{');
+    DBusAny[DBusAny] aa;
+    foreach(val; array) {
+      enforce(val.type == 'e');
+      aa[val.entry.key] = val.entry.value;
+    }
+    return aa;
+  }
+
+  /// Converts a basic type or an array to the D type with type checking. Tuples can get converted to an array.
+  T to(T)() {
+    static if(isIntegral!T || isFloatingPoint!T) {
+      switch(type) {
+      case typeCode!byte:
+        return cast(T) int8;
+      case typeCode!short:
+        return cast(T) int16;
+      case typeCode!ushort:
+        return cast(T) uint16;
+      case typeCode!int:
+        return cast(T) int32;
+      case typeCode!uint:
+        return cast(T) uint32;
+      case typeCode!long:
+        return cast(T) int64;
+      case typeCode!ulong:
+        return cast(T) uint64;
+      case typeCode!double:
+        return cast(T) float64;
+      default:
+        throw new Exception("Can't convert type " ~ cast(char) type ~ " to " ~ T.stringof);
+      }
+    } else static if(isSomeString!T) {
+      if(type == 's')
+        return str.to!T;
+      else
+        throw new Exception("Can't convert type " ~ cast(char) type ~ " to " ~ T.stringof);
+    } else static if(isDynamicArray!T) {
+      if(type != 'a' && type != 'r')
+        throw new Exception("Can't convert type " ~ cast(char) type ~ " to an array");
+      T ret;
+      foreach(elem; array)
+        ret ~= elem.to!(ElementType!T);
+      return ret;
+    } else static assert(false, "Can't convert variant to " ~ T.stringof);
+  }
+
+  bool opEquals(ref in DBusAny b) const {
+    if(b.type != type || b.explicitVariant != explicitVariant)
+      return false;
+    if((type == 'a' || type == 'r') && b.signature != signature)
+      return false;
+    if(type == 'a')
+      return array == b.array;
+    else if(type == 'r')
+      return tuple == b.tuple;
+    else if(type == 's')
+      return str == b.str;
+    else if(type == 'e')
+      return entry == b.entry || (entry && b.entry && *entry == *b.entry);
+    else
+      return uint64 == b.uint64;
+  }
+}
+
+/// Marks the data as variant on serialization
 struct Variant(T) {
+  ///
   T data;
 }
 

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -52,7 +52,7 @@ template basicDBus(T) {
 }
 
 template canDBus(T) {
-  static if(basicDBus!T) {
+  static if(basicDBus!T || is(T == DBusAny)) {
     enum canDBus = true;
   } else static if(isVariant!T) {
     enum canDBus = canDBus!(VariantType!T);
@@ -101,6 +101,8 @@ string typeSig(T)() if(canDBus!T) {
     return "s";
   } else static if(isVariant!T) {
     return "v";
+  } else static if(is(T == DBusAny)) {
+    static assert(false, "Cannot determine type signature of DBusAny. Change to Variant!DBusAny if a variant was desired.");
   } else static if(isTuple!T) {
     string sig = "(";
     foreach(i, S; T.Types) {


### PR DESCRIPTION
Functions can now have `Variant!DBusAny` as argument type or return it to support the `v` type in the function signature with dynamic types. Before you could only specify a `Variant!T` which forced the value to be of type `T` but using DBusAny now allows the value to be of any type.