### PR TITLE
Documentation update & tick function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __dummy.html
 /ddbus
 libddbus.*
 __test__library__
+/ddbus-test-*

--- a/Readme.md
+++ b/Readme.md
@@ -158,10 +158,13 @@ runTask({
 });
 ```
 
+It would be better to watch a file descriptor asynchronously in the event loop instead of checking on a timer, but that hasn't been implemented yet, see Todo.
+
 # Todo
 
 `ddbus` should be complete for everyday use but is missing some fanciness that it easily could and should have:
 
+- Support for adding file descriptors to event loops like vibe.d so that it only wakes up when messages arrive and not on a timer.
 - Marshaling of DBus path and file descriptor objects
 - Better efficiency in some places, particularly the object wrapping allocates tons of delegates for every method.
 

--- a/dub.json
+++ b/dub.json
@@ -1,12 +1,12 @@
 {
 	"name": "ddbus",
 	"description": "A DBus library for D",
-  "homepage": "http://github.com/trishume/ddbus",
-	"copyright": "Copyright © 2015, Tristan Hume",
+  "homepage": "https://github.com/trishume/ddbus",
+	"copyright": "Copyright © 2017, Tristan Hume",
   "license": "MIT",
   "authors": ["Tristan Hume"],
   "lflags": ["-ldbus-1"],
 	"dependencies": {
-      "dunit": "~>1.0.10"
+      "dunit": "~>1.0.14"
 	}
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dunit": "1.0.10"
+		"dunit": "1.0.14"
 	}
 }

--- a/source/ddbus/bus.d
+++ b/source/ddbus/bus.d
@@ -31,6 +31,12 @@ void simpleMainLoop(Connection conn) {
   while(dbus_connection_read_write_dispatch(conn.conn, -1)) {} // empty loop body
 }
 
+/// Single tick in the DBus connection which can be used for
+/// concurrent updates.
+bool tick(Connection conn) {
+  return cast(bool) dbus_connection_read_write_dispatch(conn.conn, 0);
+}
+
 unittest {
   import dunit.toolkit;
   Connection conn = connectToBus();


### PR DESCRIPTION
* added new executable test names for dub to gitignore
* Changed readme version to 2.0.0 (assuming you release the new version as 2.0.0), make sure you merge this before releasing the version so it is visible in the dub registry/readme
* Added tuple & variant!DBusAny documentation to README
* Removed notes about not being able to use it concurrently, created a function with a timeout of 0 which can be used in vibe.d or a custom main loop instead
* Updated copyright year to 2017
* Updated dependencies
* Changed repo url to `https`