### PR TITLE
Dictionary related improvements

### DIFF
--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -59,11 +59,13 @@ template canDBus(T) {
   } else static if(isTuple!T) {
     enum canDBus = allCanDBus!(T.Types);
   } else static if(isInputRange!T) {
-    enum canDBus = canDBus!(ElementType!T);
+    static if(is(ElementType!T == DictionaryEntry!(K, V), K, V)) {
+      enum canDBus = basicDBus!K && canDBus!V;
+    } else {
+      enum canDBus = canDBus!(ElementType!T);
+    }
   } else static if(isAssociativeArray!T) {
-    enum canDBus = canDBus!(KeyType!T) && canDBus!(ValueType!T);
-  } else static if(is(T == DictionaryEntry!(K, V), K, V)) {
-    enum canDBus = canDBus!K && canDBus!V;
+    enum canDBus = basicDBus!(KeyType!T) && canDBus!(ValueType!T);
   } else {
     enum canDBus = false;
   }
@@ -163,7 +165,7 @@ unittest {
   typeSig!(Tuple!(byte)[][]).assertEqual("aa(y)");
   // dictionaries
   typeSig!(int[string]).assertEqual("a{si}");
-  typeSig!(DictionaryEntry!(string, int)).assertEqual("{si}");
+  typeSig!(DictionaryEntry!(string, int)[]).assertEqual("a{si}");
   // multiple arguments
   typeSigAll!(int,bool).assertEqual("ib");
   // type codes

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -112,13 +112,18 @@ string typeSig(T)() if(canDBus!T) {
     } 
     sig ~= ")";
     return sig;
-  } else static if(is(T == DictionaryEntry!(K, V), K, V)) {
-    return '{' ~ typeSig!K ~ typeSig!V ~ '}';
   } else static if(isInputRange!T) {
     return "a" ~ typeSig!(ElementType!T)();
   } else static if(isAssociativeArray!T) {
     return "a{" ~ typeSig!(KeyType!T) ~ typeSig!(ValueType!T) ~ "}";
   }
+}
+
+string typeSig(T)() if(isInstanceOf!(DictionaryEntry, T)) {
+  static if(is(T == DictionaryEntry!(K, V), K, V)) // need to get K and V somehow
+    return "{" ~ typeSig!K ~ typeSig!V ~ '}';
+  else
+    static assert (false, "DictionaryEntry always has a key type and value type, right?");
 }
 
 string[] typeSigReturn(T)() if(canDBus!T) {
@@ -147,6 +152,10 @@ string[] typeSigArr(TS...)() if(allCanDBus!TS) {
 int typeCode(T)() if(canDBus!T) {
   string sig = typeSig!T();
   return sig[0];
+}
+
+int typeCode(T)() if(isInstanceOf!(DictionaryEntry, T) && canDBus!(T[])) {
+  return 'e';
 }
 
 unittest {

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -120,10 +120,9 @@ string typeSig(T)() if(canDBus!T) {
 }
 
 string typeSig(T)() if(isInstanceOf!(DictionaryEntry, T)) {
-  static if(is(T == DictionaryEntry!(K, V), K, V)) // need to get K and V somehow
-    return "{" ~ typeSig!K ~ typeSig!V ~ '}';
-  else
-    static assert (false, "DictionaryEntry always has a key type and value type, right?");
+  alias typeof(T.key) K;
+  alias typeof(T.value) V;
+  return "{" ~ typeSig!K ~ typeSig!V ~ '}';
 }
 
 string[] typeSigReturn(T)() if(canDBus!T) {


### PR DESCRIPTION
The DBus typesystem does not allow stand-alone dictionary entries, they must be in an array to form a dictionary. Also, DBus requires the key type of a dictionary to be a basic type. The ddbus implementation did not reflect that, thus leaving the potential to create and send invalid messages. This PR solves that. Some other parts of the code needed modification to accommodate this change.

In the process, I eliminated `DictionaryEntry` from the handling of associative arrays in conv.d.

In fact I'd like to gradually eliminate `DictionaryEntry` and `DBusAny` altogether, in favour of D native AAs and `std.variant.Variant`.