### PR TITLE
Error handling improvements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ It currently supports:
 
 - Calling methods
 - Creating wrapper objects for DBus interfaces
-- Seamlessly converting too and from D types
+- Seamlessly converting to and from D types
 - Handling method calls and signals (includes introspection support)
 
 # Installation
@@ -130,6 +130,7 @@ msg.readTuple!(typeof(args))().assertEqual(args);
 - `simple`: simpler wrappers around other functionality.
 - `conv`: low level type marshaling methods.
 - `util`: templates for working with D type marshaling like `canDBus!T`.
+- `exception`: exception classes
 - `c_lib`: a D translation of the DBus C headers.
 
 Importing `ddbus` publicly imports the `thin`,`router`,`bus` and `simple` modules.
@@ -169,7 +170,7 @@ It would be better to watch a file descriptor asynchronously in the event loop i
 `ddbus` should be complete for everyday use but is missing some fanciness that it easily could and should have:
 
 - Support for adding file descriptors to event loops like vibe.d so that it only wakes up when messages arrive and not on a timer.
-- Marshaling of DBus path and file descriptor objects
+- Marshaling of file descriptor objects
 - Better efficiency in some places, particularly the object wrapping allocates tons of delegates for every method.
 
 Pull requests are welcome, the codebase is pretty small and other than the template metaprogramming for type marshaling is fairly straightforward.

--- a/source/ddbus/exception.d
+++ b/source/ddbus/exception.d
@@ -1,0 +1,37 @@
+module ddbus.exception;
+
+import ddbus.c_lib;
+
+package T wrapErrors(T)(
+  T delegate(DBusError *err) del,
+  string file = __FILE__,
+  size_t line = __LINE__,
+  Throwable next = null
+) {
+  DBusError error;
+  dbus_error_init(&error);
+  T ret = del(&error);
+  if(dbus_error_is_set(&error)) {
+    auto ex = new DBusException(&error, file, line, next);
+    dbus_error_free(&error);
+    throw ex;
+  }
+  return ret;
+}
+
+/++
+  Thrown when a DBus error code was returned by libdbus.
++/
+class DBusException : Exception {
+  private this(
+    scope DBusError *err,
+    string file = __FILE__,
+    size_t line = __LINE__,
+    Throwable next = null
+  ) pure nothrow {
+    import std.string : fromStringz;
+
+    super(err.message.fromStringz().idup, file, line, next);
+  }
+}
+

--- a/source/ddbus/exception.d
+++ b/source/ddbus/exception.d
@@ -35,3 +35,32 @@ class DBusException : Exception {
   }
 }
 
+/++
+  Thrown when the signature of a message does not match the requested types.
++/
+class TypeMismatchException : Exception {
+  package this(
+    int expectedType,
+    int actualType,
+    string file = __FILE__,
+    size_t line = __LINE__,
+    Throwable next = null
+  ) pure nothrow @safe {
+    _expectedType = expectedType;
+    _actualType = actualType;
+    super("The type of value at the current position in the message does not match the type of value to be read."
+      ~ " Expected: " ~ cast(char) expectedType ~ ", Got: " ~ cast(char) actualType);
+  }
+
+  int expectedType() @property pure const nothrow @nogc {
+    return _expectedType;
+  }
+
+  int actualType() @property pure const nothrow @nogc {
+    return _actualType;
+  }
+
+  private:
+  int _expectedType;
+  int _actualType;
+}

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -12,23 +12,8 @@ import std.conv;
 import std.range;
 import std.algorithm;
 
-class DBusException : Exception {
-  this(DBusError *err) {
-    super(err.message.fromStringz().idup);
-  }
-}
-
-T wrapErrors(T)(T delegate(DBusError *err) del) {
-  DBusError error;
-  dbus_error_init(&error);
-  T ret = del(&error);
-  if(dbus_error_is_set(&error)) {
-    auto ex = new DBusException(&error);
-    dbus_error_free(&error);
-    throw ex;
-  }
-  return ret;
-}
+// This import is public for backwards compatibility
+public import ddbus.exception : wrapErrors, DBusException;
 
 struct ObjectPath {
   private string _value;


### PR DESCRIPTION
- Moved `wrapErrors` and `DBusException` from `ddbus.thin` into a new `ddbus.exception` module. Also improved the implementation of those to match general D exception conventions. Placed a public import in `ddbus.thin` for backwards compatibility.
- Removed incorrect assertions in `ddbus.conv.readIter`.
  Those asserts could be triggered while parsing incoming messages that happen to contain other types of values than expected. As any data coming from outside the application should never be trusted, and thus any errors therein should be handled gracefully, triggering an assert in such case is incorrect. Also, asserts are ignored in release builds, so those might even segfault because execution continues with incorrect data (e.g. when expecting a `string`, but getting an `int`). Therefore a new `TypeMismatchException` has been created and is thrown if the type of value at the cursor doesn't match the type to be read.
- Added mention of the new `ddbus.exception` module to the README.
  (And as I was editing the README anyway, fixed a typo and removed DBus paths from the TODO, as support for that is already in master.)