### PR TITLE
Support Phobos variants

### DIFF
--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -122,7 +122,7 @@ void buildIter(TS...)(DBusMessageIter *iter, TS args) if(allCanDBus!TS) {
       }
       if(val.explicitVariant)
         dbus_message_iter_close_container(iter, sub);
-    } else static if(isVariant!T) {
+    } else static if(isInstanceOf!(Variant, T)) {
       DBusMessageIter sub;
       const(char)* subSig = typeSig!(VariantType!T).toStringz();
       dbus_message_iter_open_container(iter, 'v', subSig, &sub);
@@ -188,7 +188,7 @@ T readIter(T)(DBusMessageIter *iter) if (!is(T == enum) && !isInstanceOf!(BitFla
   auto argType = dbus_message_iter_get_arg_type(iter);
   T ret;
 
-  static if(!isVariant!T || is(T == Variant!DBusAny)) {
+  static if(!isInstanceOf!(Variant, T) || is(T == Variant!DBusAny)) {
     if(argType == 'v') {
       DBusMessageIter sub;
       dbus_message_iter_recurse(iter, &sub);
@@ -242,7 +242,7 @@ T readIter(T)(DBusMessageIter *iter) if (!is(T == enum) && !isInstanceOf!(BitFla
         ret ~= readIter!U(&sub);
       }
     }
-  } else static if(isVariant!T) {
+  } else static if(isInstanceOf!(Variant, T)) {
     DBusMessageIter sub;
     dbus_message_iter_recurse(iter, &sub);
     ret.data = readIter!(VariantType!T)(&sub);

--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -173,7 +173,7 @@ T readIter(T)(DBusMessageIter *iter) if (isInstanceOf!(BitFlags, T)) {
   alias TemplateArgsOf!T[0] E;
   alias OriginalType!E B;
 
-  B mask = only(EnumMembers!E).fold!((a, b) => a | b);
+  B mask = only(EnumMembers!E).fold!((a, b) => cast(B) (a | b));
 
   B value = readIter!B(iter);
   enforce(

--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -10,6 +10,7 @@ import std.string;
 import std.typecons;
 import std.range;
 import std.traits;
+import std.variant : VariantN;
 
 void buildIter(TS...)(DBusMessageIter *iter, TS args) if(allCanDBus!TS) {
   foreach(index, arg; args) {
@@ -56,6 +57,19 @@ void buildIter(TS...)(DBusMessageIter *iter, TS args) if(allCanDBus!TS) {
         dbus_message_iter_close_container(&sub, &entry);
       }
       dbus_message_iter_close_container(iter, &sub);
+    } else static if(isInstanceOf!(VariantN, T)) {
+      enforce(arg.hasValue,
+        new InvalidValueException(arg, "dbus:" ~ cast(char) typeCode!T));
+
+      DBusMessageIter sub;
+      foreach(AT; T.AllowedTypes) {
+        if (arg.peek!AT) {
+          dbus_message_iter_open_container(iter, 'v', typeSig!AT.ptr, &sub);
+          buildIter(&sub, arg.get!AT);
+          dbus_message_iter_close_container(iter, &sub);
+          break;
+        }
+      }
     } else static if(is(T == DBusAny) || is(T == Variant!DBusAny)) {
       static if(is(T == Variant!DBusAny)) {
         auto val = arg.data;
@@ -171,10 +185,11 @@ T readIter(T)(DBusMessageIter *iter) if (isInstanceOf!(BitFlags, T)) {
 }
 
 T readIter(T)(DBusMessageIter *iter) if (!is(T == enum) && !isInstanceOf!(BitFlags, T) && canDBus!T) {
+  auto argType = dbus_message_iter_get_arg_type(iter);
   T ret;
 
   static if(!isVariant!T || is(T == Variant!DBusAny)) {
-    if(dbus_message_iter_get_arg_type(iter) == 'v') {
+    if(argType == 'v') {
       DBusMessageIter sub;
       dbus_message_iter_recurse(iter, &sub);
       static if(is(T == Variant!DBusAny)) {
@@ -188,8 +203,12 @@ T readIter(T)(DBusMessageIter *iter) if (!is(T == enum) && !isInstanceOf!(BitFla
       return ret;
     }
   }
-  static if(!is(T == DBusAny) && !is(T == Variant!DBusAny)) {
-    auto argType = dbus_message_iter_get_arg_type(iter);
+
+  static if(
+    !is(T == DBusAny)
+    && !is(T == Variant!DBusAny)
+    && !isInstanceOf!(VariantN, T)
+  ) {
     enforce(argType == typeCode!T(),
       new TypeMismatchException(typeCode!T(), argType));
   }
@@ -227,6 +246,25 @@ T readIter(T)(DBusMessageIter *iter) if (!is(T == enum) && !isInstanceOf!(BitFla
     DBusMessageIter sub;
     dbus_message_iter_recurse(iter, &sub);
     ret.data = readIter!(VariantType!T)(&sub);
+  } else static if(isInstanceOf!(VariantN, T)) {
+    scope const(char)[] argSig =
+      dbus_message_iter_get_signature(iter).fromStringz();
+    scope(exit)
+      dbus_free(cast(void*) argSig.ptr);
+
+    foreach(AT; T.AllowedTypes) {
+      // We have to compare the full signature here, not just the typecode.
+      // Otherwise, in case of container types, we might select the wrong one.
+      // We would then be calling an incorrect instance of readIter, which would
+      // probably throw a TypeMismatchException.
+      if (typeSig!AT == argSig) {
+        ret = readIter!AT(iter);
+        break;
+      }
+    }
+
+    // If no value is in ret, apparently none of the types matched.
+    enforce(ret.hasValue, new TypeMismatchException(typeCode!T, argType));
   } else static if(isAssociativeArray!T) {
     DBusMessageIter sub;
     dbus_message_iter_recurse(iter, &sub);
@@ -239,7 +277,7 @@ T readIter(T)(DBusMessageIter *iter) if (!is(T == enum) && !isInstanceOf!(BitFla
       dbus_message_iter_next(&sub);
     }
   } else static if(is(T == DBusAny)) {
-    ret.type = dbus_message_iter_get_arg_type(iter);
+    ret.type = argType;
     ret.explicitVariant = false;
     if(ret.type == 's') {
       ret.str = readIter!string(iter);
@@ -428,11 +466,16 @@ unittest {
   import dunit.toolkit;
   import ddbus.thin;
 
+  import std.variant : Algebraic;
+
   enum E : int { a, b, c }
   enum F : uint { x = 1, y = 2, z = 4 }
+  alias V = Algebraic!(byte, short, int, long, string);
 
   Message msg = Message("org.example.wow", "/wut", "org.test.iface", "meth2");
-  msg.build(E.c, 4, 5u, 8u);
+  V v1 = "hello from variant";
+  V v2 = cast(short) 345;
+  msg.build(E.c, 4, 5u, 8u, v1, v2);
 
   DBusMessageIter iter, iter2;
   dbus_message_iter_init(msg.msg, &iter);
@@ -446,5 +489,8 @@ unittest {
 
   readIter!F(&iter).assertThrow!InvalidValueException();
   readIter!(BitFlags!F)(&iter2).assertThrow!InvalidValueException();
+
+  readIter!V(&iter).assertEqual(v1);
+  readIter!short(&iter).assertEqual(v2.get!short);
 }
 

--- a/source/ddbus/exception.d
+++ b/source/ddbus/exception.d
@@ -48,15 +48,20 @@ class TypeMismatchException : Exception {
   ) pure nothrow @safe {
     _expectedType = expectedType;
     _actualType = actualType;
-    super("The type of value at the current position in the message does not match the type of value to be read."
-      ~ " Expected: " ~ cast(char) expectedType ~ ", Got: " ~ cast(char) actualType);
+    if (expectedType == 'v') {
+      super("The type of value at the current position in the message is incompatible to the target variant type."
+        ~ " Type code of the value: " ~ cast(char) actualType);
+    } else {
+      super("The type of value at the current position in the message does not match the type of value to be read."
+        ~ " Expected: " ~ cast(char) expectedType ~ ", Got: " ~ cast(char) actualType);
+    }
   }
 
-  int expectedType() @property pure const nothrow @nogc {
+  int expectedType() @property pure const nothrow @safe @nogc {
     return _expectedType;
   }
 
-  int actualType() @property pure const nothrow @nogc {
+  int actualType() @property pure const nothrow @safe @nogc {
     return _actualType;
   }
 

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -17,6 +17,15 @@ auto byDictionaryEntries(K, V)(V[K] aa) {
   return aa.byKeyValue.map!(pair => DictionaryEntry!(K, V)(pair.key, pair.value));
 }
 
+/+
+  Predicate template indicating whether T is an instance of ddbus.thin.Variant.
+
+  Deprecated:
+    This template used to be undocumented and user code should not depend on it.
+    Its meaning became unclear when support for Phobos-style variants was added.
+    It seemed best to remove it at that point.
++/
+deprecated("Use std.traits.isInstanceOf instead.")
 template isVariant(T) {
   static if(isBasicType!T || isInputRange!T) {
     enum isVariant = false;
@@ -61,7 +70,7 @@ template basicDBus(T) {
 template canDBus(T) {
   static if(basicDBus!T || is(T == DBusAny)) {
     enum canDBus = true;
-  } else static if(isVariant!T) {
+  } else static if(isInstanceOf!(Variant, T)) {
     enum canDBus = canDBus!(VariantType!T);
   } else static if(isInstanceOf!(VariantN, T)) {
     // Phobos-style variants are supported if limited to DBus compatible types.
@@ -116,7 +125,7 @@ string typeSig(T)() if(canDBus!T) {
     return "s";
   } else static if(is(T == ObjectPath)) {
     return "o";
-  } else static if(isVariant!T || isInstanceOf!(VariantN, T)) {
+  } else static if(isInstanceOf!(Variant, T) || isInstanceOf!(VariantN, T)) {
     return "v";
   } else static if(is(T B == enum)) {
     return typeSig!B;


### PR DESCRIPTION
Phobos variants are accepted and handled much like `Variant!DBusAny`.

A Phobos variant type
- Must be restricted to ddbus-compatible types (so `std.variant.Variant` won't work, but `std.variant.Algebraic!(int, double, string)` does)
- Maps to the variant (`v`) DBus type
