### PR TITLE
ObjectPath improvements

### DIFF
--- a/source/ddbus/simple.d
+++ b/source/ddbus/simple.d
@@ -8,6 +8,10 @@ import std.string;
 import std.traits;
 
 class PathIface {
+  this(Connection conn, string dest, ObjectPath path, string iface) {
+    this(conn, dest, path.value, iface);
+  }
+
   this(Connection conn, string dest, string path, string iface) {
     this.conn = conn;
     this.dest = dest.toStringz();

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -16,9 +16,8 @@ import std.algorithm;
 public import ddbus.exception : wrapErrors, DBusException;
 
 struct ObjectPath {
-  private string _value;
-
-  this(string objPath) {
+  /// Creates and validates a ObjectPath from a string
+  this(string objPath) @safe {
     enforce(_isValid(objPath));
     _value = objPath;
   }
@@ -26,6 +25,19 @@ struct ObjectPath {
   string toString() const {
     return _value;
   }
+
+  /// Returns the string representation of this ObjectPath
+  string value() const pure nothrow @safe {
+    return _value;
+  }
+
+  /// Sets and validates the string representation of this ObjectPath
+  string value(string newVal) @safe {
+    enforce(_isValid(newVal));
+    return _value = newVal;
+  }
+
+  alias value this;
 
   size_t toHash() const pure nothrow @trusted {
     return hashOf(_value);
@@ -35,7 +47,11 @@ struct ObjectPath {
     return _value == b._value;
   }
 
-  private static bool _isValid(string objPath) {
+  bool opEquals(const typeof(this) b) const pure nothrow @safe {
+    return _value == b._value;
+  }
+
+  private static bool _isValid(string objPath) @trusted {
     import std.regex : matchFirst, ctRegex;
     return cast(bool) objPath.matchFirst(ctRegex!("^((/[0-9A-Za-z_]+)+|/)$"));
   }


### PR DESCRIPTION
* ObjectPath can now be compared with non-ref types (eg `objpath == ObjectPath.init`)
* You can now get/set the raw string value of ObjectPath (mark the variable as const if you don't want that)
* PathIface allows ObjectPaths in the constructor