### PR TITLE
Add get!T method to DBusAny

### DIFF
--- a/source/ddbus/exception.d
+++ b/source/ddbus/exception.d
@@ -36,7 +36,9 @@ class DBusException : Exception {
 }
 
 /++
-  Thrown when the signature of a message does not match the requested types.
+  Thrown when the signature of a message does not match the requested types or
+  when trying to get a value from a DBusAny object that does not match the type
+  of its actual value.
 +/
 class TypeMismatchException : Exception {
   package this(
@@ -46,15 +48,33 @@ class TypeMismatchException : Exception {
     size_t line = __LINE__,
     Throwable next = null
   ) pure nothrow @safe {
+    string message;
+
+    if (expectedType == 'v') {
+      message = "The type of value at the current position in the message is"
+        ~ " incompatible to the target variant type."
+        ~ " Type code of the value: '" ~ cast(char) actualType ~ '\'';
+    } else {
+      message = "The type of value at the current position in the message does"
+        ~ " not match the type of value to be read."
+        ~ " Expected: '" ~ cast(char) expectedType ~ "',"
+        ~ " Got: '" ~ cast(char) actualType ~ '\'';
+    }
+
+    this(message, expectedType, actualType, file, line, next);
+  }
+
+  package this(
+    string message,
+    int expectedType,
+    int actualType,
+    string file = __FILE__,
+    size_t line = __LINE__,
+    Throwable next = null
+  ) pure nothrow @safe {
     _expectedType = expectedType;
     _actualType = actualType;
-    if (expectedType == 'v') {
-      super("The type of value at the current position in the message is incompatible to the target variant type."
-        ~ " Type code of the value: " ~ cast(char) actualType);
-    } else {
-      super("The type of value at the current position in the message does not match the type of value to be read."
-        ~ " Expected: " ~ cast(char) expectedType ~ ", Got: " ~ cast(char) actualType);
-    }
+    super(message, file, line, next);
   }
 
   int expectedType() @property pure const nothrow @safe @nogc {

--- a/source/ddbus/exception.d
+++ b/source/ddbus/exception.d
@@ -64,7 +64,7 @@ class TypeMismatchException : Exception {
     this(message, expectedType, actualType, file, line, next);
   }
 
-  package this(
+  this(
     string message,
     int expectedType,
     int actualType,

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -249,7 +249,7 @@ struct DBusAny {
         valueStr = '[' ~ array.map!(a => a.toString).join(", ") ~ ']';
       break;
     case 'r':
-      valueStr = '(' ~ array.map!(a => a.toString).join(", ") ~ ')';
+      valueStr = '(' ~ tuple.map!(a => a.toString).join(", ") ~ ')';
       break;
     case 'e':
       valueStr = entry.key.toString ~ ": " ~ entry.value.toString;

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -344,7 +344,10 @@ struct DBusAny {
   }
 
   /++
-    Get the type signature of the value stored in this DBusAny object.
+    Get the DBus type signature of the value stored in the DBusAny object.
+
+    Returns:
+      The type signature of the value stored in this DBusAny object.
    +/
   string typeSig() @property const pure nothrow @safe
   {

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -268,42 +268,47 @@ struct DBusAny {
   }
 
   /++
-    Returns the value stored in the DBusAny object by specifying the type.
+    Get the value stored in the DBusAny object.
 
     Parameters:
       T = The requested type. The currently stored value must match the
         requested type exactly.
+
+    Returns:
+      The current value of the DBusAny object.
 
     Throws:
       TypeMismatchException if the DBus type of the current value of the
       DBusAny object is not the same as the DBus type used to represent T.
   +/
   T get(T)() @property const
-    if (staticIndexOf!(T, BasicTypes) >= 0)
+    if(staticIndexOf!(T, BasicTypes) >= 0)
   {
     enforce(type == typeCode!T,
       new TypeMismatchException(
         "Cannot get a " ~ T.stringof ~ " from a DBusAny with"
           ~ " a value of DBus type '" ~ typeSig ~ "'.", typeCode!T, type));
 
-    static if (isIntegral!T) {
+    static if(isIntegral!T) {
       enum memberName =
-        (isUnsigned!T ? "uint" : "int") ~ (T.sizeof << 3).to!string;
+        (isUnsigned!T ? "uint" : "int") ~ (T.sizeof * 8).to!string;
       return __traits(getMember, this, memberName);
-    } else static if (is(T == double)) {
+    } else static if(is(T == double)) {
       return float64;
-    } else static if (is(T == string)) {
+    } else static if(is(T == string)) {
       return str;
-    } else static if (is(T == ObjectPath)) {
+    } else static if(is(T == ObjectPath)) {
       return obj;
-    } else static if (is(T == bool)) {
+    } else static if(is(T == bool)) {
       return boolean;
+    } else {
+      static assert(false);
     }
   }
 
   /// ditto
   T get(T)() @property const
-    if (is(T == const(DBusAny)[]))
+    if(is(T == const(DBusAny)[]))
   {
     enforce((type == 'a' && signature != "y") || type == 'r',
       new TypeMismatchException(
@@ -343,11 +348,11 @@ struct DBusAny {
    +/
   string typeSig() @property const pure nothrow @safe
   {
-    if (type == 'a') {
+    if(type == 'a') {
       return "a" ~ signature;
-    } else if (type == 'r') {
+    } else if(type == 'r') {
       return signature;
-    } else if (type == 'e') {
+    } else if(type == 'e') {
       return () @trusted {
         return "{" ~ entry.key.signature ~ entry.value.signature ~ "}";
       } ();
@@ -470,10 +475,10 @@ unittest {
     assertEqual(DBusAny(value), b);
 
     static if(is(T == Variant!R, R)) {
-      static if (__traits(compiles, b.get!R))
+      static if(__traits(compiles, b.get!R))
         assertEqual(b.get!R, value.data);
     } else {
-      static if (__traits(compiles, b.get!T))
+      static if(__traits(compiles, b.get!T))
         assertEqual(b.get!T, value);
     }
 

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -468,6 +468,15 @@ unittest {
 
   void test(T)(T value, DBusAny b) {
     assertEqual(DBusAny(value), b);
+
+    static if(is(T == Variant!R, R)) {
+      static if (__traits(compiles, b.get!R))
+        assertEqual(b.get!R, value.data);
+    } else {
+      static if (__traits(compiles, b.get!T))
+        assertEqual(b.get!T, value);
+    }
+
     assertEqual(b.to!T, value);
     b.toString();
   }

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -1,9 +1,10 @@
 module ddbus.util;
 
 import ddbus.thin;
-import std.typecons;
+import std.meta : AliasSeq, staticIndexOf;
 import std.range;
 import std.traits;
+import std.typecons : BitFlags, isTuple, Tuple;
 import std.variant : VariantN;
 
 struct DictionaryEntry(K, V) {
@@ -51,11 +52,26 @@ template allCanDBus(TS...) {
   }
 }
 
+/++
+  AliasSeq of all basic types in terms of the DBus typesystem
+ +/
+package // Don't add to the API yet, 'cause I intend to move it later
+alias BasicTypes = AliasSeq!(
+  bool,
+  byte,
+  short,
+  ushort,
+  int,
+  uint,
+  long,
+  ulong,
+  double,
+  string,
+  ObjectPath
+);
+
 template basicDBus(T) {
-  static if(is(T == byte) || is(T == short) || is (T == ushort) || is (T == int)
-            || is (T == uint) || is (T == long) || is (T == ulong)
-            || is (T == double) || is (T == string) || is(T == bool)
-            || is (T == ObjectPath)) {
+  static if(staticIndexOf!(T, BasicTypes) >= 0) {
     enum basicDBus = true;
   } else static if(is(T B == enum)) {
     enum basicDBus = basicDBus!B;


### PR DESCRIPTION
Efficiently get values without type conversion.

This is also meant to somewhat align `DBusAny` with Phobos variants.

A follow-up PR will refactor `DBusAny.to`, using `get` where possible.

BTW, I know the unittest is ugly. It will be better after the refactor of `to`, because then `get` can be tested by just testing `to`.