### PR TITLE
Allow structs with non-marshaled non-canDBus fields

### DIFF
--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -7,7 +7,7 @@ import ddbus.util;
 import ddbus.thin;
 
 import std.exception : enforce;
-import std.meta: allSatisfy;
+import std.meta: allSatisfy, Filter;
 import std.string;
 import std.typecons;
 import std.range;
@@ -344,7 +344,8 @@ void readIterTuple(Tup)(DBusMessageIter *iter, ref Tup tuple) if(isTuple!Tup && 
   }
 }
 
-void readIterStruct(S)(DBusMessageIter *iter, ref S s) if(is(S == struct) && allCanDBus!(Fields!S)) {
+void readIterStruct(S)(DBusMessageIter *iter, ref S s) if(is(S == struct) && canDBus!S)
+{
   foreach(index, T; Fields!S) {
     static if (isAllowedField!(s.tupleof[index])) {
       s.tupleof[index] = readIter!T(iter);

--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -7,7 +7,7 @@ import ddbus.util;
 import ddbus.thin;
 
 import std.exception : enforce;
-import std.meta: allSatisfy, Filter;
+import std.meta: allSatisfy;
 import std.string;
 import std.typecons;
 import std.range;

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -654,6 +654,7 @@ unittest {
   struct S2 {
     int h, i;
     @(Yes.DBusMarshal) int j, k;
+    int *p;
   }
 
   @dbusMarshaling(MarshalingFlag.includePrivateFields)

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -668,10 +668,12 @@ unittest {
 
   Message msg = Message("org.example.wow", "/wut", "org.test.iface", "meth3");
 
+  __gshared int dummy;
+
   enum testStruct = S3(
     variant(5), "blah",
     S1(-7, 63.5, "test"),
-    S2(84, -123, 78, 432),
+    S2(84, -123, 78, 432, &dummy),
     16
   );
 
@@ -681,7 +683,7 @@ unittest {
   enum expectedResult = S3(
     variant(5), "blah",
     S1(int.init, 63.5, "test"),
-    S2(int.init, int.init, 78, 432),
+    S2(int.init, int.init, 78, 432, null),
     uint.init
   );
 

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -86,7 +86,7 @@ template canDBus(T) {
   } else static if(isAssociativeArray!T) {
     enum canDBus = basicDBus!(KeyType!T) && canDBus!(ValueType!T);
   } else static if(is(T == struct) && !isInstanceOf!(DictionaryEntry, T)) {
-    enum canDBus = allCanDBus!(Fields!T);
+    enum canDBus = allCanDBus!(AllowedFieldTypes!T);
   } else {
     enum canDBus = false;
   }
@@ -147,7 +147,7 @@ string typeSig(T)() if(canDBus!T) {
     return "a{" ~ typeSig!(KeyType!T) ~ typeSig!(ValueType!T) ~ "}";
   } else static if(is(T == struct)) {
     string sig = "(";
-    foreach(i, S; Fields!T) {
+    foreach(i, S; AllowedFieldTypes!T) {
       sig ~= typeSig!S();
     }
     sig ~= ")";
@@ -241,3 +241,11 @@ unittest {
   sig3.assertEqual("iss"); 
 }
 
+private template AllowedFieldTypes(S) if (is(S == struct)) {
+  import ddbus.attributes : isAllowedField;
+  import std.meta : Filter, staticMap;
+  static alias TypeOf(alias sym) = typeof(sym);
+
+  alias AllowedFieldTypes =
+    staticMap!(TypeOf, Filter!(isAllowedField, S.tupleof));
+}


### PR DESCRIPTION
An attempt to send/receive a struct with a non-marshaled field of a non-canDBus type caused a compile time error.

This PR fixes that and adds such a field to one of the unittests.