### PR TITLE
DBusAny: Reimplementation of to!T() and struct support

### DIFF
--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -639,17 +639,6 @@ unittest {
 
   void test(T)(T value, DBusAny b) {
     assertEqual(DBusAny(value), b);
-
-    static if (is(T == Variant!R, R)) {
-      static if (__traits(compiles, b.get!R)) {
-        assertEqual(b.get!R, value.data);
-      }
-    } else {
-      static if (__traits(compiles, b.get!T)) {
-        assertEqual(b.get!T, value);
-      }
-    }
-
     assertEqual(b.to!T, value);
     b.toString();
   }
@@ -661,7 +650,10 @@ unittest {
   test(cast(uint) 184, set!"uint32"(DBusAny('u', null, false), cast(uint) 184));
   test(cast(long) 184, set!"int64"(DBusAny('x', null, false), cast(long) 184));
   test(cast(ulong) 184, set!"uint64"(DBusAny('t', null, false), cast(ulong) 184));
+  test(1.84, set!"float64"(DBusAny('d', null, false), 1.84));
   test(true, set!"boolean"(DBusAny('b', null, false), true));
+  test("abc", set!"str"(DBusAny('s', null, false), "abc"));
+  test(ObjectPath("/foo/Bar"), set!"obj"(DBusAny('o', null, false), ObjectPath("/foo/Bar")));
   test(cast(ubyte[])[1, 2, 3], set!"binaryData"(DBusAny('a', ['y'], false),
       cast(ubyte[])[1, 2, 3]));
 
@@ -672,7 +664,11 @@ unittest {
   test(variant(cast(uint) 184), set!"uint32"(DBusAny('u', null, true), cast(uint) 184));
   test(variant(cast(long) 184), set!"int64"(DBusAny('x', null, true), cast(long) 184));
   test(variant(cast(ulong) 184), set!"uint64"(DBusAny('t', null, true), cast(ulong) 184));
+  test(variant(1.84), set!"float64"(DBusAny('d', null, true), 1.84));
   test(variant(true), set!"boolean"(DBusAny('b', null, true), true));
+  test(variant("abc"), set!"str"(DBusAny('s', null, true), "abc"));
+  test(variant(ObjectPath("/foo/Bar")), set!"obj"(DBusAny('o', null, true),
+      ObjectPath("/foo/Bar")));
   test(variant(cast(ubyte[])[1, 2, 3]), set!"binaryData"(DBusAny('a', ['y'],
       true), cast(ubyte[])[1, 2, 3]));
 

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -432,7 +432,7 @@ struct DBusAny {
       if (is(T == const(DBusAny)[])) {
     enforce((type == 'a' && signature != "y") || type == 'r', new TypeMismatchException(
         "Cannot get a " ~ T.stringof ~ " from a DBusAny with" ~ " a value of DBus type '" ~ this.typeSig ~ "'.",
-        typeCode!T, type));
+        'a', type));
 
     return array;
   }
@@ -442,7 +442,7 @@ struct DBusAny {
       if (is(T == const(ubyte)[])) {
     enforce(type == 'a' && signature == "y", new TypeMismatchException(
         "Cannot get a " ~ T.stringof ~ " from a DBusAny with" ~ " a value of DBus type '" ~ this.typeSig ~ "'.",
-        typeCode!T, type));
+        'a', type));
 
     return binaryData;
   }

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -532,32 +532,22 @@ struct DBusAny {
         alias E = Unqual!(ElementType!T);
 
         if (typeSig == "ay") {
+          auto data = get!(const(ubyte)[]);
           static if (is(E == ubyte) || is(E == byte)) {
-            return cast(T) binaryData.dup;
+            return cast(T) data.dup;
           } else {
-            T ret;
-            ret.length = binaryData.length;
-
-            foreach (i, b; binaryData)
-              ret[i] = b;
-
-            return ret;
+            return cast(T) data.map!(elem => elem.to!E).array;
           }
         } else if (type == 'a' || (type == 'r' && is(E == DBusAny))) {
-          E[] ret;
-          ret.length = array.length;
-
-          foreach (i, elem; array)
-            ret[i] = elem.to!(ElementType!T);
-
-          return cast(T) ret;
+          return cast(T) get!(const(DBusAny)[]).map!(elem => elem.to!E).array;
         }
       } else static if (isTuple!T) {
         if (type == 'r') {
           T ret;
 
-          foreach (i, T; ret.Types)
+          foreach (i, T; ret.Types) {
             ret[i] = tuple[i].to!T;
+          }
 
           return ret;
         }

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -175,15 +175,24 @@ struct DBusAny {
     ubyte[] binaryData;
   }
 
-  /// Manually creates a DBusAny object using a type, signature and implicit specifier.
+  /++
+    Manually creates a DBusAny object using a type, signature and explicit
+    variant specifier.
+
+    Direct use of this constructor from user code should be avoided.
+   +/
   this(int type, string signature, bool explicit) {
     this.type = type;
     this.signature = signature;
     this.explicitVariant = explicit;
   }
 
-  /// Automatically creates a DBusAny object with fitting parameters from a D type or Variant!T.
-  /// Pass a `Variant!T` to make this an explicit variant.
+  /++
+    Automatically creates a DBusAny object with fitting parameters from a D
+    type or Variant!T.
+
+    Pass a `Variant!T` to make this an explicit variant.
+   +/
   this(T)(T value) {
     static if (is(T == byte) || is(T == ubyte)) {
       this(typeCode!byte, null, false);


### PR DESCRIPTION
This PR updates the `DBusAny.to` method to use the recently added `DBusAny.get` where possible. Also support for `struct` types has been added to `DBusAny`.

The unittest in this PR revealed bug #34, so that one gets fixed here too.

When this is in, I think it's about time to tag release v2.3, I'll work on updating the README.
