### PR TITLE
safer API with ObjectPath, InterfaceName, BusName

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,9 @@ msg.readTuple!(typeof(args))().assertEqual(args);
 ```
 ### Basic types
 These are the basic types supported by `ddbus`:
-`bool`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `double`, `string`, `ObjectPath`
+`bool`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `double`, `string`, `ObjectPath`, `InterfaceName`, `BusName`
+
+ObjectPath, InterfaceName and BusName are typesafe wrappers or aliases around strings which should be used to ensure type-safety. They do not allow implicit casts to each other but can be manually converted to strings either by casting to string.
 
 ### Overview of mappings of other types:
 

--- a/examples/client/source/app.d
+++ b/examples/client/source/app.d
@@ -4,12 +4,12 @@ import ddbus;
 
 void testCall(Connection conn) {
   for(int i = 0; i < 50; i++) {
-    Message msg =  Message("ca.thume.transience","/ca/thume/transience/screensurface",
-                               "ca.thume.transience.screensurface","testDot");
+    Message msg =  Message(busName("ca.thume.transience"), ObjectPath("/ca/thume/transience/screensurface"),
+                          interfaceName("ca.thume.transience.screensurface"), "testDot");
     conn.sendBlocking(msg);
   }
-  Message msg2 = Message("ca.thume.transience","/ca/thume/transience/screensurface",
-                            "ca.thume.transience.screensurface","testPing");
+  Message msg2 = Message(busName("ca.thume.transience"), ObjectPath("/ca/thume/transience/screensurface"),
+                        interfaceName("ca.thume.transience.screensurface"), "testPing");
   Message res = conn.sendWithReplyBlocking(msg2, 3.seconds);
   int result = res.read!int();
   writeln(result);

--- a/examples/server/source/app.d
+++ b/examples/server/source/app.d
@@ -3,18 +3,18 @@ import ddbus;
 
 void testServe(Connection conn) {
   auto router = new MessageRouter();
-  MessagePattern patt = MessagePattern("/root","ca.thume.test","test");
+  MessagePattern patt = MessagePattern(ObjectPath("/root"), interfaceName("ca.thume.test"), "test");
   router.setHandler!(int,int)(patt,(int par) {
       writeln("Called with ", par);
       return par;
     });
-  patt = MessagePattern("/signaler","ca.thume.test","signal",true);
+  patt = MessagePattern(ObjectPath("/signaler"), interfaceName("ca.thume.test"), "signal",true);
   router.setHandler!(void,int)(patt,(int par) {
       writeln("Signalled with ", par);
     });
   registerRouter(conn, router);
   writeln("Getting name...");
-  bool gotem = requestName(conn, "ca.thume.ddbus.test");
+  bool gotem = requestName(conn, busName("ca.thume.ddbus.test"));
   writeln("Got name: ",gotem);
   simpleMainLoop(conn);
 }

--- a/source/ddbus/bus.d
+++ b/source/ddbus/bus.d
@@ -5,9 +5,9 @@ import ddbus.thin;
 import ddbus.c_lib;
 import std.string;
 
-enum BusService = "org.freedesktop.DBus";
-enum BusPath = "/org/freedesktop/DBus";
-enum BusInterface = "org.freedesktop.DBus";
+enum BusService = busName("org.freedesktop.DBus");
+enum BusInterface = interfaceName("org.freedesktop.DBus");
+enum BusPath = ObjectPath("/org/freedesktop/DBus");
 
 enum NameFlags {
   AllowReplace = 1,
@@ -15,10 +15,16 @@ enum NameFlags {
   NoQueue = 4
 }
 
+deprecated("Use the overload taking a BusName instead")
+bool requestName(Connection conn, string name,
+    NameFlags flags = NameFlags.NoQueue | NameFlags.AllowReplace) {
+  return requestName(conn, busName(name), flags);
+}
+
 /// Requests a DBus well-known name.
 /// returns if the name is owned after the call.
 /// Involves blocking call on a DBus method, may throw an exception on failure.
-bool requestName(Connection conn, string name,
+bool requestName(Connection conn, BusName name,
     NameFlags flags = NameFlags.NoQueue | NameFlags.AllowReplace) {
   auto msg = Message(BusService, BusPath, BusInterface, "RequestName");
   msg.build(name, cast(uint)(flags));
@@ -44,5 +50,5 @@ unittest {
   import dunit.toolkit;
 
   Connection conn = connectToBus();
-  conn.requestName("ca.thume.ddbus.testing").assertTrue();
+  conn.requestName(busName("ca.thume.ddbus.testing")).assertTrue();
 }

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -55,7 +55,7 @@ template allCanDBus(TS...) {
  +/
 package  // Don't add to the API yet, 'cause I intend to move it later
 alias BasicTypes = AliasSeq!(bool, byte, short, ushort, int, uint, long, ulong,
-    double, string, ObjectPath);
+    double, string, ObjectPath, InterfaceName, BusName);
 
 template basicDBus(T) {
   static if (staticIndexOf!(T, BasicTypes) >= 0) {
@@ -126,7 +126,7 @@ string typeSig(T)()
     return "t";
   } else static if (is(T == double)) {
     return "d";
-  } else static if (is(T == string)) {
+  } else static if (is(T == string) || is(T == InterfaceName) || is(T == BusName)) {
     return "s";
   } else static if (is(T == ObjectPath)) {
     return "o";
@@ -208,6 +208,10 @@ int typeCode(T)()
 unittest {
   import dunit.toolkit;
 
+  static assert(canDBus!ObjectPath);
+  static assert(canDBus!InterfaceName);
+  static assert(canDBus!BusName);
+
   // basics
   typeSig!int().assertEqual("i");
   typeSig!bool().assertEqual("b");
@@ -276,8 +280,8 @@ unittest {
   sig.assertEqual("t");
   static string sig2 = typeSig!(Tuple!(int, string, string));
   sig2.assertEqual("(iss)");
-  static string sig3 = typeSigAll!(int, string, string);
-  sig3.assertEqual("iss");
+  static string sig3 = typeSigAll!(int, string, InterfaceName, BusName);
+  sig3.assertEqual("isss");
 }
 
 private template AllowedFieldTypes(S)


### PR DESCRIPTION
the busName and interfacePath types transparently cast down to a string, (but not the other way around) so they are a perfect upgrade to type-safety. The only downside to them is that templates can often get them wrong. std.conv.to will return with a cast(T) prefix, which could slightly break existing code.

I think the type-safety advantages are outweighing this corner case though. (as you have to opt-in in most cases except for when accessing paths and names of Message objects) The current API has been fully upgraded and examples still run and work, as well as a personal project I tested (without changing any code)

A new 3.0 release would probably fit well for this.