### PR TITLE
Fix deprecation warning of std.digest

### DIFF
--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -444,7 +444,7 @@ struct DBusAny {
       valueStr = boolean ? "true" : "false";
       break;
     case 'a':
-      import std.digest.digest : toHexString;
+      import std.digest : toHexString;
 
       if (signature == ['y']) {
         valueStr = "binary(" ~ binaryData.toHexString ~ ')';


### PR DESCRIPTION
std.digest.digest got renamed in 2.076.0 and was supposed to be removed in 2.084.0 (though it's still in)
https://dlang.org/changelog/2.076.0.html#std-digest-package