### PR TITLE
Replace 'byte' with 'ubyte'.

### DIFF
--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -450,7 +450,7 @@ unittest {
     z = 4
   }
 
-  alias V = Algebraic!(byte, short, int, long, string);
+  alias V = Algebraic!(ubyte, short, int, long, string);
 
   Message msg = Message(busName("org.example.wow"), ObjectPath("/wut"), interfaceName("org.test.iface"), "meth2");
   V v1 = "hello from variant";

--- a/source/ddbus/router.d
+++ b/source/ddbus/router.d
@@ -275,7 +275,7 @@ unittest {
   }
 
   struct S {
-    byte b;
+    ubyte b;
     ulong ul;
     F f;
   }

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -222,7 +222,7 @@ struct DBusAny {
 
   union {
     ///
-    byte int8;
+    ubyte uint8;
     ///
     short int16;
     ///
@@ -273,8 +273,8 @@ struct DBusAny {
    +/
   this(T)(T value) {
     static if (is(T == byte) || is(T == ubyte)) {
-      this(typeCode!byte, null, false);
-      int8 = cast(byte) value;
+      this(typeCode!ubyte, null, false);
+      uint8 = cast(ubyte) value;
     } else static if (is(T == short)) {
       this(typeCode!short, null, false);
       int16 = cast(short) value;
@@ -410,8 +410,8 @@ struct DBusAny {
   string toString() const {
     string valueStr;
     switch (type) {
-    case typeCode!byte:
-      valueStr = int8.to!string;
+    case typeCode!ubyte:
+      valueStr = uint8.to!string;
       break;
     case typeCode!short:
       valueStr = int16.to!string;
@@ -712,7 +712,7 @@ unittest {
     b.toString();
   }
 
-  test(cast(ubyte) 184, set!"int8"(DBusAny('y', null, false), cast(byte) 184));
+  test(cast(ubyte) 184, set!"uint8"(DBusAny('y', null, false), cast(ubyte) 184));
   test(cast(short) 184, set!"int16"(DBusAny('n', null, false), cast(short) 184));
   test(cast(ushort) 184, set!"uint16"(DBusAny('q', null, false), cast(ushort) 184));
   test(cast(int) 184, set!"int32"(DBusAny('i', null, false), cast(int) 184));
@@ -726,7 +726,7 @@ unittest {
   test(cast(ubyte[])[1, 2, 3], set!"binaryData"(DBusAny('a', ['y'], false),
       cast(ubyte[])[1, 2, 3]));
 
-  test(variant(cast(ubyte) 184), set!"int8"(DBusAny('y', null, true), cast(byte) 184));
+  test(variant(cast(ubyte) 184), set!"uint8"(DBusAny('y', null, true), cast(ubyte) 184));
   test(variant(cast(short) 184), set!"int16"(DBusAny('n', null, true), cast(short) 184));
   test(variant(cast(ushort) 184), set!"uint16"(DBusAny('q', null, true), cast(ushort) 184));
   test(variant(cast(int) 184), set!"int32"(DBusAny('i', null, true), cast(int) 184));

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -54,7 +54,7 @@ template allCanDBus(TS...) {
   AliasSeq of all basic types in terms of the DBus typesystem
  +/
 package  // Don't add to the API yet, 'cause I intend to move it later
-alias BasicTypes = AliasSeq!(bool, byte, short, ushort, int, uint, long, ulong,
+alias BasicTypes = AliasSeq!(bool, ubyte, short, ushort, int, uint, long, ulong,
     double, string, ObjectPath, InterfaceName, BusName);
 
 template basicDBus(T) {
@@ -108,7 +108,7 @@ unittest {
 
 string typeSig(T)()
     if (canDBus!T) {
-  static if (is(T == byte)) {
+  static if (is(T == ubyte)) {
     return "y";
   } else static if (is(T == bool)) {
     return "b";
@@ -218,13 +218,13 @@ unittest {
   typeSig!string().assertEqual("s");
   typeSig!(Variant!int)().assertEqual("v");
   // enums
-  enum E : byte {
+  enum E : ubyte {
     a,
     b,
     c
   }
 
-  typeSig!E().assertEqual(typeSig!byte());
+  typeSig!E().assertEqual(typeSig!ubyte());
   enum U : string {
     One = "One",
     Two = "Two"
@@ -262,7 +262,7 @@ unittest {
   // arrays
   typeSig!(int[]).assertEqual("ai");
   typeSig!(Variant!int[]).assertEqual("av");
-  typeSig!(Tuple!(byte)[][]).assertEqual("aa(y)");
+  typeSig!(Tuple!(ubyte)[][]).assertEqual("aa(y)");
   // dictionaries
   typeSig!(int[string]).assertEqual("a{si}");
   typeSig!(DictionaryEntry!(string, int)[]).assertEqual("a{si}");


### PR DESCRIPTION
Because 'y' is unsigned in the DBus spec.

Fixes issue #49 