### PR TITLE
Implement DBusErrorReturn for nicer error return interface.

### DIFF
--- a/source/ddbus/exception.d
+++ b/source/ddbus/exception.d
@@ -28,6 +28,24 @@ class DBusException : Exception {
 }
 
 /++
+  Throw this from a handler to have it automatically translate to an Error
+  reply.
++/
+class DBusErrorReturn : Exception {
+  string errorName = "org.freedesktop.DBus.Error.Failed";
+
+  this(string errMsg, string file = __FILE__, size_t line = __LINE__,
+      Throwable next = null) pure nothrow {
+    super(errMsg, file, line, next);
+  }
+
+  typeof(this) withErrorName(string _errorName) {
+    errorName = _errorName;
+    return this;
+  }
+}
+
+/++
   Thrown when the signature of a message does not match the requested types or
   when trying to get a value from a DBusAny object that does not match the type
   of its actual value.

--- a/source/ddbus/package.d
+++ b/source/ddbus/package.d
@@ -5,3 +5,4 @@ public import ddbus.router;
 public import ddbus.bus;
 public import ddbus.simple;
 public import ddbus.attributes;
+public import ddbus.exception : DBusErrorReturn;

--- a/source/ddbus/router.d
+++ b/source/ddbus/router.d
@@ -150,6 +150,14 @@ class MessageRouter {
     callTable[patt] = handleStruct;
   }
 
+  unittest {
+    auto router = new MessageRouter;
+    auto patt = MessagePattern(ObjectPath("/org/myorg/service"), interfaceName("org.myorg.service"), "", false);
+    router.setHandler(patt, (string arg) {
+      return arg.length;
+    });
+  }
+
   static string introspectHeader = `<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="%s">`;
 

--- a/source/ddbus/simple.d
+++ b/source/ddbus/simple.d
@@ -71,6 +71,9 @@ void registerMethods(T : Object)(MessageRouter router, string path, string iface
    working so if some methods randomly don't seem to be added, you should probably use
    setHandler on the router directly. It is also not efficient and creates a closure for every method.
 
+   The handler may throw a DBusErrorReturn to generate a DBus error response to
+   the request.
+
    TODO: replace this with something that generates a wrapper class who's methods take and return messages
    and basically do what MessageRouter.setHandler does but avoiding duplication. Then this DBusWrapper!Class
    could be instantiated with any object efficiently and placed in the router table with minimal duplication.


### PR DESCRIPTION
As discussed in issue #51.

Sample usage:
````
class MyService {
    Tuple!(ObjectPath, ObjectPath)
    CreateCollection(string[string] props, string _alias)
    {
        if (_alias != "default")
            throw new DBusErrorReturn("org.freedesktop.DBus.Error.NotSupported", 
                "operation not supported");
        return tuple(ObjectPath("/org/myorg/myservice/objects/default"),
            ObjectPath("/"));
    }
}

auto router = new MessageRouter();
auto serv = new MyService;
registerMethods(router, ObjectPath("/org/myorg/myservice"),
    interfaceName("org.myorg.myservice.myintf"), serv);
````