### PR TITLE
Added FileDescriptor support

### DIFF
--- a/source/ddbus/conv.d
+++ b/source/ddbus/conv.d
@@ -172,7 +172,7 @@ void buildIter(TS...)(DBusMessageIter* iter, TS args)
 }
 
 T readIter(T)(DBusMessageIter* iter)
-    if (is(T == enum) && !is(T == InterfaceName) && !is(T == BusName)) {
+    if (is(T == enum) && !is(T == InterfaceName) && !is(T == BusName) && !is(T == FileDescriptor)) {
   import std.algorithm.searching : canFind;
 
   alias OriginalType!T B;
@@ -198,7 +198,8 @@ T readIter(T)(DBusMessageIter* iter)
 }
 
 T readIter(T)(DBusMessageIter* iter)
-    if (!(is(T == enum) && !is(T == InterfaceName) && !is(T == BusName)) && !isInstanceOf!(BitFlags, T) && canDBus!T) {
+    if (!(is(T == enum) && !is(T == InterfaceName) && !is(T == BusName) && !is(T == FileDescriptor))
+    && !isInstanceOf!(BitFlags, T) && canDBus!T) {
   auto argType = dbus_message_iter_get_arg_type(iter);
   T ret;
 

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -268,6 +268,7 @@ struct DBusAny {
     DictionaryEntry!(DBusAny, DBusAny)* entry;
     ///
     ubyte[] binaryData;
+    ///
     FileDescriptor fd;
   }
 

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -177,8 +177,10 @@ InterfaceName interfaceName(string path) pure @nogc nothrow @safe {
 
 /// Serving as a typesafe alias for a FileDescriptor.
 enum FileDescriptor : int {
-  none = -1,
-  max = int.max
+  none   = -1,
+  stdin  = 0,
+  stdout = 1,
+  stderr = 2
 }
 
 /// Casts an integer to a FileDescriptor.
@@ -266,6 +268,7 @@ struct DBusAny {
     DictionaryEntry!(DBusAny, DBusAny)* entry;
     ///
     ubyte[] binaryData;
+    FileDescriptor fd;
   }
 
   /++
@@ -301,7 +304,7 @@ struct DBusAny {
       int32 = cast(int) value;
     } else static if (is(T == FileDescriptor)) {
       this(typeCode!FileDescriptor, null, false);
-      int32 = cast(int) value;
+      fd = cast(FileDescriptor) value;
     } else static if (is(T == uint)) {
       this(typeCode!uint, null, false);
       uint32 = cast(uint) value;
@@ -511,7 +514,7 @@ struct DBusAny {
         typeCode!T, type));
 
     static if (is(T == FileDescriptor)) {
-      return fileDescriptor(int32);
+      return cast(U) fd;
     } else  static if (isIntegral!T) {
       enum memberName = (isUnsigned!T ? "uint" : "int") ~ (T.sizeof * 8).to!string;
       return cast(U) __traits(getMember, this, memberName);

--- a/source/ddbus/thin.d
+++ b/source/ddbus/thin.d
@@ -176,15 +176,15 @@ InterfaceName interfaceName(string path) pure @nogc nothrow @safe {
 }
 
 /// Serving as a typesafe alias for a FileDescriptor.
-enum FileDescriptor : int {
-  none   = -1,
+enum FileDescriptor : uint {
+  none   = uint.max,
   stdin  = 0,
   stdout = 1,
   stderr = 2
 }
 
 /// Casts an integer to a FileDescriptor.
-FileDescriptor fileDescriptor(int fileNo) pure @nogc nothrow @safe {
+FileDescriptor fileDescriptor(uint fileNo) pure @nogc nothrow @safe {
   return cast(FileDescriptor) fileNo;
 }
 
@@ -776,7 +776,8 @@ unittest {
   test(variant(cast(short) 184), set!"int16"(DBusAny('n', null, true), cast(short) 184));
   test(variant(cast(ushort) 184), set!"uint16"(DBusAny('q', null, true), cast(ushort) 184));
   test(variant(cast(int) 184), set!"int32"(DBusAny('i', null, true), cast(int) 184));
-  test(variant(cast(FileDescriptor) 184), set!"int32"(DBusAny('h', null, true), cast(FileDescriptor) 184));
+  test(variant(cast(FileDescriptor) 184), set!"uint32"(DBusAny('h', null, true), cast(FileDescriptor) 184));
+  test(variant(cast(FileDescriptor) FileDescriptor.none), set!"uint32"(DBusAny('h', null, true), cast(FileDescriptor) FileDescriptor.none));
   test(variant(cast(uint) 184), set!"uint32"(DBusAny('u', null, true), cast(uint) 184));
   test(variant(cast(long) 184), set!"int64"(DBusAny('x', null, true), cast(long) 184));
   test(variant(cast(ulong) 184), set!"uint64"(DBusAny('t', null, true), cast(ulong) 184));

--- a/source/ddbus/util.d
+++ b/source/ddbus/util.d
@@ -55,7 +55,7 @@ template allCanDBus(TS...) {
  +/
 package  // Don't add to the API yet, 'cause I intend to move it later
 alias BasicTypes = AliasSeq!(bool, byte, short, ushort, int, uint, long, ulong,
-    double, string, ObjectPath, InterfaceName, BusName);
+    double, string, ObjectPath, InterfaceName, BusName, FileDescriptor);
 
 template basicDBus(T) {
   static if (staticIndexOf!(T, BasicTypes) >= 0) {
@@ -104,6 +104,7 @@ unittest {
   (canDBus!(Tuple!(int[], bool, Variant!short))).assertTrue();
   (canDBus!(Tuple!(int[], int[string]))).assertTrue();
   (canDBus!(int[string])).assertTrue();
+  (canDBus!FileDescriptor).assertTrue();
 }
 
 string typeSig(T)()
@@ -116,6 +117,8 @@ string typeSig(T)()
     return "n";
   } else static if (is(T == ushort)) {
     return "q";
+  } else static if (is(T == FileDescriptor)) {
+    return "h";
   } else static if (is(T == int)) {
     return "i";
   } else static if (is(T == uint)) {
@@ -217,6 +220,7 @@ unittest {
   typeSig!bool().assertEqual("b");
   typeSig!string().assertEqual("s");
   typeSig!(Variant!int)().assertEqual("v");
+  typeSig!FileDescriptor().assertEqual("h");
   // enums
   enum E : byte {
     a,
@@ -256,9 +260,10 @@ unittest {
     string d;
     S1 e;
     uint f;
+    FileDescriptor g;
   }
 
-  typeSig!S2.assertEqual("(vs(ids)u)");
+  typeSig!S2.assertEqual("(vs(ids)uh)");
   // arrays
   typeSig!(int[]).assertEqual("ai");
   typeSig!(Variant!int[]).assertEqual("av");


### PR DESCRIPTION
Some DBus methods return file descriptors, such as
"org.freedesktop.login1.Manager.Inhibit". This commit adds support for
these.

I followed the same enum type defining pattern I've seen in the code,
such as with InterfaceNames and BusNames, to prevent integers and
fileDescriptors implicitly casting to each other.

Note that it is kinda hard to test with reading and writing
fileDescriptors, as DBus will duplicate the file descriptor
when reading, leading to relatively unpredicatable behaviour.

I also must admit I focussed most of my attention to reading file
descriptors and less to writing file descriptors, as I don't know a good
way to test those.