### PR TITLE
Improvements in meson build files

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
 src_inc = include_directories('source')
 
 prefix = get_option('prefix')
-include_dir = join_paths(prefix, get_option('includedir'), 'd', 'apk-polkit')
+include_dir = join_paths(prefix, get_option('includedir'), 'd', 'ddbus')
 
 dbus_dep = dependency('dbus-1')
 

--- a/meson.build
+++ b/meson.build
@@ -13,3 +13,9 @@ include_dir = join_paths(prefix, get_option('includedir'), 'd', 'apk-polkit')
 dbus_dep = dependency('dbus-1')
 
 subdir('source/ddbus')
+
+ddbus_dep = declare_dependency(
+    include_directories: src_inc,
+    link_with: ddbus_lib
+)
+

--- a/source/ddbus/meson.build
+++ b/source/ddbus/meson.build
@@ -15,6 +15,7 @@ ddbus_lib = library(
     'ddbus',
     lib_src,
     version: meson.project_version(),
+    dependencies: [dbus_dep],
     install: true,
     include_directories: src_inc,
 )

--- a/source/ddbus/meson.build
+++ b/source/ddbus/meson.build
@@ -20,6 +20,11 @@ ddbus_lib = library(
     include_directories: src_inc,
 )
 
+ddbus_dep = declare_dependency(
+    include_directories: src_inc,
+    link_with: ddbus_lib
+)
+
 pkgc = import('pkgconfig')
 
 pkgc.generate(


### PR DESCRIPTION
* I've added libdbus as a dependency of the build target. This avoids linker errors.
* I've declared ddbus as a dependency, so other projects can use this library as a subproject
* I've renamed the include directory from apk-polkit to ddbus, since the former looks like a mistake