### PR TITLE
Add support for calling void methods on interfaces

### DIFF
--- a/source/ddbus/simple.d
+++ b/source/ddbus/simple.d
@@ -33,6 +33,13 @@ class PathIface {
     return ret.read!Ret();
   }
 
+  void call(Ret, Args...)(string meth, Args args)
+      if (allCanDBus!Args && is(Ret == void)) {
+    Message msg = Message(dbus_message_new_method_call(dest, path, iface, meth.toStringz()));
+    msg.build(args);
+    conn.sendBlocking(msg);
+  }
+
   Message opDispatch(string meth, Args...)(Args args) {
     Message msg = Message(dbus_message_new_method_call(dest, path, iface, meth.toStringz()));
     msg.build(args);


### PR DESCRIPTION
It is currently not possible to call a methods that does not have any output. This patch adds support for calling such functions.